### PR TITLE
fix log path error on windows

### DIFF
--- a/hyuga/log.hy
+++ b/hyuga/log.hy
@@ -1,8 +1,10 @@
 (import logging)
 (import traceback)
+(import os.path)
+(import tempfile)
 
 (setv logger (logging.getLogger "hyuga"))
-(let [handler (logging.FileHandler :filename "/tmp/hyuga.log")]
+(let [handler (logging.FileHandler :filename (os.path.join (tempfile.gettempdir) "hyuga.log"))]
   (.setLevel logger logging.DEBUG)
   (.setFormatter handler (logging.Formatter "%(levelname)-9s %(asctime)s [%(name)s] %(message)s"))
   (logger.addHandler handler))


### PR DESCRIPTION
fix log path error on windows:

```
FileNotFoundError: [Errno 2] No such file or directory: 'c:\\tmp\\hyuga.log'
```