### PR TITLE
Added additional information to make installing Hyuga easier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,71 @@ Please report the results [in issues](https://github.com/sakuraiyuta/hyuga/issue
 
 ## Install
 
-### plain install
+### Regular Global Install
 
 ```bash
 pip3 install hyuga
 ```
 
+On Arch based systems, or other systems that use an externally managed Python environment where the above is not possible:
+```bash
+pipx install hyuga
+```
+Also, ensure you installed `hy` the same way via `pipx`, not `pacman`/`yay`, as the package has not yet been updated to `1.0.0`, and is currently stuck at `0.29.0-1` for the moment. This likely won't apply in the future as it will inevitably be updated, but `pipx` is generally the safer route here as it pulls it straight from pypi, and doesn't depend on a maintainer to keep it up to date. 
+
+## Setup
+
+### [Neovim(nvim)](https://github.com/neovim/neovim) Lua setup via [lspconfig](https://github.com/neovim/nvim-lspconfig)
+
+Install [vim-hy](https://github.com/hylang/vim-hy) for filetype detection. This is optional, as you can register the filetype yourself, but you'll likely want to run this anyway if you're using Hy with Neovim, as it provides syntax highlighting among other things.
+
+Then define an entry for Hyuga:
+
+```lua
+local lspconfig = require("lspconfig")
+local lsp_configs = require("lspconfig.configs")
+
+if not lsp_configs.hy then
+  lsp_configs.hy = {
+    default_config = {
+      cmd = { 'hyuga' },
+      filetypes = { 'hy' },
+      root_dir = function(fname)
+        return lspconfig.util.path.dirname(fname)
+      end,
+    },
+    docs = {
+      description = "Hyuga language server for the Hy programming language, a Python dialect of LISP"
+    }
+  }
+end
+```
+
+And finally, don't forget to run setup! As a reference, here's how I have it set up. I prefer to defer setup (you may need to run `:LspStart` in case it doesn't auto-attach on the first `hy` file that gets opened, but only the first)
+```lua
+vim.api.nvim_create_autocmd("FileType", {
+  once = true,
+  pattern = 'hy',
+  callback = function(_)
+    local ls_entry = lsp_configs.hy
+    ls_entry.setup {
+      -- Any extended capabilities or custom on_attach functions go here as usual,
+      -- e.g. for nvim-cmp other such plugins where you'd extend capabilities:
+      -- capabilities = extended_capabilities,
+      -- on_attach = custom_on_attach
+      -- Can just be left blank, but included for reference. 
+    }
+  end
+})
+```
+
+---
+
 ### [neovim(nvim)](https://github.com/neovim/neovim) + [vim-lsp](https://github.com/prabirshrestha/vim-lsp) + [vim-lsp-settings](https://github.com/mattn/vim-lsp-settings)
 
 Install [vim-lsp](https://github.com/prabirshrestha/vim-lsp) and [vim-lsp-settings](https://github.com/mattn/vim-lsp-settings), open a `*.hy` file with `filetype=hy`, then run `:LspInstallServer`
+
+---
 
 ### [Visual Studio Code(VSCode)](https://code.visualstudio.com)
 


### PR DESCRIPTION
Instructions on how to register Hyuga using [lspconfig](https://github.com/neovim/nvim-lspconfig) have been added, and instructions on the installation of Hyuga itself on Linux distributions that use [externally managed Python environments](https://packaging.python.org/en/latest/specifications/externally-managed-environments/#externally-managed-environments) (primarily Arch), where trying to `pip3 install hyuga` without `--break-system-packages` is literally impossible, have also been added ([pipx](https://github.com/pypa/pipx), [as mentioned in the aforementioned spec](https://packaging.python.org/en/latest/specifications/externally-managed-environments/#guide-users-towards-virtual-environments) is the most common way of installing packages via pip on EME distros)

These additions are all hurdles I faced that I had to figure out myself. I'm hoping to include this information so that the next person doesn't have to go through the same 2 hour installation process I had to go through.

That, and [lspconfig](https://github.com/neovim/nvim-lspconfig) is generally the most popular way to deal with language servers in Neovim nowadays.

I hope this helps save someone from a future headache.