### PR TITLE
Expand test coverage

### DIFF
--- a/tests/api.hy
+++ b/tests/api.hy
@@ -8,6 +8,18 @@
 (import misc *)
 
 (defn [(pytest.mark.parametrize
+        #("src" "root_uri" "doc_uri" "expected")
+        [#("(import toolz.itertoolz *)"
+           "."
+           "."
+           None)])]
+  test_parse-src
+  [src root-uri doc-uri expected]
+  (print f"expected: { expected }" )
+  (print f"got:      { (parse-src! src root-uri doc-uri) }")
+  (assert (= (parse-src! src root-uri doc-uri) expected)))
+
+(defn [(pytest.mark.parametrize
          #("val" "expected")
          [#("eval"
              {"sym"   "\\(builtin)\\eval"
@@ -24,13 +36,12 @@
               "scope" ".None"
               "ns"    "toolz.itertoolz"
               "docs"  (docs-str first "toolz.itertoolz")
-              "pos"   #(2, 15)})])]
+              "pos"   #(1 9)})])]
   test_get-details
   [val expected fixture-syms pytestconfig]
   (setv roots (+ "file://" (os.path.join pytestconfig.rootdir "tests" "api.hy")))
-;   (print (get-details val roots roots))
-;   (print)
-;   (print expected)
+  (print f"expected: { expected }" )
+  (print f"got:      { (get-details val roots roots) }")
   (assert (= (get-details val roots roots) expected)))
 
 (defn [(pytest.mark.parametrize
@@ -59,29 +70,29 @@
                  "scope" ""
                  "ns"    "(hykwd)"
                  "docs"  (docs-str (get-macro eval-when-compile) "(hykwd)")
-                 "pos"   None})))
-         ;  #("filter" 
-         ;    #(#("\\(builtin)\\filter"
-         ;        {"sym"   "\\(builtin)\\filter"
-         ;         "type"  filter
-         ;         "uri"   False
-         ;         "scope" ""
-         ;         "ns"    "(builtin)"
-         ;         "docs"  (docs-str filter "(builtin)")
-         ;         "pos"   None})
-         ;      #("\\(sysenv)\\filter"
-         ;        {"sym"   "\\(sysenv)\\filter"
-         ;         "type"  (importlib.import_module "sym.filter" :package "filter")
-         ;         "uri"   False
-         ;         "scope" "" 
-         ;         "ns"    "(sysenv)"
-         ;         "docs"  (docs-str (importlib.import_module "sym.filter" :package "filter") "(sysenv)")
-         ;         "pos"   None})))
-          ])]
+                 "pos"   None})))])]
   test_get-candidates
-  [val expected fixture-syms pytestconfig]
+  [val expected pytestconfig]
   (setv roots (+ "file://" (os.path.join pytestconfig.rootdir "tests" "api.hy")))
-;   (print (get-candidates val roots roots))
-;   (print)
-;   (print expected)
-  (assert (= (get-candidates val roots roots) expected))) eval
+  (print f"expected: { expected }" )
+  (print f"got:      { (get-candidates val roots roots) }")
+  (assert (= (get-candidates val roots roots) expected)))
+
+(defn [(pytest.mark.parametrize
+        #("tgt_full_sym" "root_uri" "doc_uri" "expected")
+        [#("eval"
+           "."
+           "."
+           #(#("\\(builtin)\\eval" 
+               {"sym"   "\\(builtin)\\eval"
+                "type"  eval
+                "uri"   False
+                "scope" ""
+                "ns"    "(builtin)"
+                "docs"  (docs-str eval "(builtin)")
+                "pos"   None})) )])]
+  test_get-matches
+  [tgt-full-sym root-uri doc-uri expected]
+  (print f"expected: { expected }" )
+  (print f"got:      { (get-matches tgt-full-sym root-uri doc-uri) }")
+  (assert (= (get-matches tgt-full-sym root-uri doc-uri) expected)))

--- a/tests/lspspec.hy
+++ b/tests/lspspec.hy
@@ -1,0 +1,191 @@
+(require hyrule * :readers *)
+
+(import pytest)
+(import toolz.itertoolz [first])
+(import toolz)
+
+(import lsprotocol.types [Location
+                          Range
+                          Position
+                          Hover
+                          MarkupContent
+                          CompletionItem])
+
+(import misc *)
+(import hyuga.lspspec *)
+(import fixture [fixture-syms])
+
+(setv test-completion-item
+  (CompletionItem :label "[] eval"
+                  :label_details None
+                  :kind 14
+                  :tags None
+                  :detail "eval [(builtin)]\n\t<built-in function eval>\n\nEvaluate the given source in the context of globals and locals.\n\nThe source may be a string representing a Python expression\nor a code object as returned by compile().\nThe globals must be a dictionary and locals can be any mapping,\ndefaulting to the current globals and locals.\nIf only globals is given, locals defaults to it."
+                  :documentation None
+                  :deprecated None
+                  :preselect None
+                  :sort-text None
+                  :filter-text None
+                  :insert-text "eval"
+                  :insert-text-format None
+                  :insert-text-mode None
+                  :text-edit None
+                  :text-edit-text None
+                  :additional-text-edits None
+                  :commit-characters None
+                  :command None
+                  :data None))
+
+(defn [(pytest.mark.parametrize
+        #("word" "full_sym" "expected")
+        [#("eval"
+          #("eval"
+            {"sym" "\\(builtin)\\eval"
+            "type" eval
+            "uri" False
+            "scope" ""
+            "ns" "(builtin)"
+            "docs" "eval [(builtin)]\n\t<built-in function eval>\n\nEvaluate the given source in the context of globals and locals.\n\nThe source may be a string representing a Python expression\nor a code object as returned by compile().\nThe globals must be a dictionary and locals can be any mapping,\ndefaulting to the current globals and locals.\nIf only globals is given, locals defaults to it."
+            "pos" None}) 
+           test-completion-item)])]
+  test_create-item
+  [word full-sym expected]
+  (print f"expected: { expected }")
+  (print f"got:      { (create-item word full-sym) }")
+  (assert (= (create-item word full-sym) expected)))
+
+(setv test-completion-items 
+  [(CompletionItem :label "[(builtin)] eval" 
+                    :label_details None
+                    :kind 14 
+                    :tags None
+                    :detail "eval [(builtin)]\n\t<built-in function eval>\n\nEvaluate the given source in the context of globals and locals.\n\nThe source may be a string representing a Python expression\nor a code object as returned by compile().\nThe globals must be a dictionary and locals can be any mapping,\ndefaulting to the current globals and locals.\nIf only globals is given, locals defaults to it."
+                    :documentation None
+                    :deprecated None
+                    :preselect None
+                    :sort_text None
+                    :filter_text None 
+                    :insert_text "eval"
+                    :insert_text_format None
+                    :insert_text_mode None
+                    :text_edit None
+                    :text_edit_text None
+                    :additional_text_edits None
+                    :commit_characters None
+                    :command None
+                    :data None)
+    (CompletionItem :label "[(hykwd)] eval-and-compile" 
+                    :label_details None
+                    :kind 3 
+                    :tags None
+                    :detail "eval-and-compile [(hykwd)]\n\t<function pattern_macro.<locals>.dec.<locals>.wrapper_maker.<locals>.wrapper at 0x7f8f88462520>\n\nNo docs." 
+                    :documentation None
+                    :deprecated None
+                    :preselect None
+                    :sort_text None
+                    :filter_text None 
+                    :insert_text "eval-and-compile"
+                    :insert_text_format None
+                    :insert_text_mode None
+                    :text_edit None
+                    :text_edit_text None
+                    :additional_text_edits None
+                    :commit_characters None
+                    :command None
+                    :data None)
+    (CompletionItem :label "[(hykwd)] eval-when-compile" 
+                    :label_details None
+                    :kind 3 
+                    :tags None
+                    :detail "eval-when-compile [(hykwd)]\n\t<function pattern_macro.<locals>.dec.<locals>.wrapper_maker.<locals>.wrapper at 0x7f8f884625c0>\n\nNo docs."
+                    :documentation None
+                    :deprecated None
+                    :preselect None
+                    :sort_text None
+                    :filter_text None 
+                    :insert_text "eval-when-compile"
+                    :insert_text_format None
+                    :insert_text_mode None
+                    :text_edit None
+                    :text_edit_text None
+                    :additional_text_edits None
+                    :commit_characters None
+                    :command None
+                    :data None)])
+
+(defn [(pytest.mark.parametrize
+        #("word" "root_uri" "doc_uri" "expected")
+        [#("eval"
+           ""
+           ""
+           test-completion-items)])]
+  test_create-items
+  [word root-uri doc-uri expected] 
+  (print f"expected: { expected }")
+  (print f"got:      { (create-items word root-uri doc-uri) }")
+  (assert (= (get (create-items word root-uri doc-uri) 0) 
+             (get expected 0))))
+
+(defn [(pytest.mark.parametrize
+        #("items" "expected")
+        [#(test-completion-items
+           (CompletionList :is_incomplete False 
+                           :items test-completion-items))])]
+  test_create-completion-list
+  [items expected] 
+  (print f"expected: { expected }")
+  (print f"got:      { (create-completion-list items) }")
+  (assert (= (create-completion-list items) expected)))
+
+(defn [(pytest.mark.parametrize
+        #("docs" "expected")
+        [#("test string" 
+           (Hover
+            :contents (MarkupContent 
+                       :kind MarkupKind.PlainText
+                       :value (fix-dummy "test string"))))])]
+  test_create-hover
+  [docs expected]
+  (print f"expected: { expected }")
+  (print f"got:      { (create-hover docs) }")
+  (assert (= (create-hover docs) expected)))
+
+(setv test-location
+  (let [obj-pos (Position :line (-> #(1 1) first dec) 
+                          :character (-> #(1 1) second dec)) 
+        obj-range (Range :start obj-pos 
+                         :end obj-pos)] 
+    (Location :uri "file:///home/cdfig/projects/hy/hyuga/tests/misc.hy"  
+              :range obj-range)))
+
+(defn [(pytest.mark.parametrize
+        #("pos" "uri" "expected")
+        [#(#(1 1) "file:///home/cdfig/projects/hy/hyuga/tests/misc.hy" 
+           test-location)])]
+  test_create-location
+  [pos uri expected]
+  (print f"expected: { expected }")
+  (print f"got:      { (create-location pos uri) }")
+  (assert (= (create-location pos uri) expected)))
+
+(defn [(pytest.mark.parametrize
+        #("items" "expected")
+        [#([test-location] 
+           [test-location])])]
+  test_distinct-locations
+  [items expected]
+  (print f"expected: { expected }")
+  (print f"got:      { (distinct-locations items) }")
+  (assert (= (distinct-locations items) expected)))
+
+(defn [(pytest.mark.parametrize
+         #("symvals" "expected")
+         [#([["docs-str"
+              {"pos" #(1 1)
+               "uri" "file:///home/cdfig/projects/hy/hyuga/tests/misc.hy"}]]
+            [test-location])])]
+  test_create-location-list
+  [symvals expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (create-location-list symvals) }")
+  (assert (= (create-location-list symvals) expected)))

--- a/tests/sym/summary.hy
+++ b/tests/sym/summary.hy
@@ -1,0 +1,214 @@
+(import pytest)
+
+(import hyuga.sym.summary *)
+(import fixture [fixture-syms])
+
+(defn [(pytest.mark.parametrize
+         #("form" "expected")
+         [#('(defn test [] True)
+            {"name" "test"
+             "type" "defn"
+             "docs" ""
+             "decorators" None
+             "args" (hy.models.List)
+             "pos" #(1 1)})
+          #('(defn test2 [input] "docstring" True) 
+            {"name" "test2"
+             "type" "defn"
+             "docs" "docstring"
+             "decorators" None
+             "args" (hy.models.List [(hy.models.Symbol "input")])
+             "pos" #(1 1)})])]
+  test_get-defn-summary
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-defn-summary form) }")
+  (assert (= (get-defn-summary form) expected)))
+
+(defn [(pytest.mark.parametrize 
+         #("forms" "ret" "expected")
+         [#('((defn test [] True)) {"methods" []} 
+           (hy.models.Expression 
+             [(hy.models.Expression  
+               [(hy.models.Symbol "defn")
+                (hy.models.Symbol "test")
+                (hy.models.List)
+                (hy.models.Symbol "True")])]))])]
+  test_get-defclass-methods
+  [forms ret expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-defclass-methods forms ret) }")
+  (assert (= (get-defclass-methods forms ret) expected)))
+
+(defn [(pytest.mark.parametrize 
+         #("form" "expected")
+         [#('(defclass Test [] (defn test [] True)) 
+            {"name" "Test"
+             "type" "defclass"
+             "docs" ""
+             "inherits" (hy.models.List)
+             "methods" [{"name" "test" 
+                         "type" "defn" 
+                         "docs" "" 
+                         "decorators" None 
+                         "args" (hy.models.List) 
+                         "pos" #(1 1)}]
+            "pos" #(1 1)})])]
+  test_get-defclass-summary
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-defclass-summary form) }")
+  (assert (= (get-defclass-summary form) expected)))
+
+(defn [(pytest.mark.parametrize 
+         #("form" "expected")
+         [#('(setv test True) 
+            {"name" "test"
+             "type" "setv"
+             "value" (hy.models.Symbol "True")
+             "docs" "True"
+             "pos" #(1 1)})])]
+  test_get-setv-summary
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-setv-summary form) }")
+  (assert (= (get-setv-summary form) expected)))
+
+(defn [(pytest.mark.parametrize 
+         #("form" "expected")
+         [#('(import hy) 
+            {"name" "hy"
+             "type" "import"
+             "pos" #(1 1)
+             "includes" None})
+          #('(import hyrule.collections [walk])
+            {"name" "hyrule.collections"
+             "type" "import"
+             "pos" #(1 1)
+             "includes" ["walk"]})])]
+  test_get-import-summary 
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-import-summary form) }")
+  (assert (= (get-import-summary form) expected)))
+
+(defn [(pytest.mark.parametrize 
+         #("form" "expected")
+         [#('(require hyrule.argmove [-> ->>]) 
+            {"name" "hyrule.argmove"
+             "type" "require"
+             "pos" #(1 1)
+             "includes" []})])]
+  test_get-require-summary 
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-require-summary form) }")
+  (assert (= (get-require-summary form) expected)))
+
+(defn [(pytest.mark.parametrize
+         #("form" "expected")
+         [#('(defmacro test [] '(+ 1 1)) 
+            {"name" "test"
+             "type" "defmacro"
+             "pos" #(1 1)
+             "includes" []})
+          #('(defmacro test2 [a] '(+ 1 a))
+            {"name" "test2"
+             "type" "defmacro"
+             "pos" #(1 1)
+             "includes" []})])]
+  test_get-defmacro-summary 
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-defmacro-summary form) }")
+  (assert (= (get-defmacro-summary form) expected)))
+
+(defn [(pytest.mark.parametrize
+         #("form" "expected")
+         [#('(defaweirdthing test (+ 1 1)) 
+            {"name" "test"
+             "type" "defaweirdthing"
+             "pos" #(1 1)})
+          #('(defaweirdthing test2 1000) 
+            {"name" "test2"
+             "type" "defaweirdthing"
+             "pos" #(1 1)})])]
+  test_get-unknown-def-summary 
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-unknown-def-summary form) }")
+  (assert (= (get-unknown-def-summary form) expected)))
+
+(defn [(pytest.mark.parametrize
+         #("form" "expected")
+         [#('(defaweirdthing test (+ 1 1)) 
+            {"name" "test"
+             "type" "defaweirdthing"
+             "pos" #(1 1)})
+          #('(defaweirdthing test2 1000) 
+            {"name" "test2"
+             "type" "defaweirdthing"
+             "pos" #(1 1)})
+          #('(defmacro test [] '(+ 1 1)) 
+            {"name" "test"
+             "type" "defmacro"
+             "pos" #(1 1)
+             "includes" []})
+          #('(defmacro test2 [a] '(+ 1 a))
+            {"name" "test2"
+             "type" "defmacro"
+             "pos" #(1 1)
+             "includes" []})
+          #('(require hyrule.argmove [-> ->>]) 
+            {"name" "hyrule.argmove"
+             "type" "require"
+             "pos" #(1 1)
+             "includes" []})
+          #('(import hy) 
+            {"name" "hy"
+             "type" "import"
+             "pos" #(1 1)
+             "includes" None})
+          #('(import hyrule.collections [walk])
+            {"name" "hyrule.collections"
+             "type" "import"
+             "pos" #(1 1)
+             "includes" ["walk"]})
+          #('(setv test True) 
+            {"name" "test"
+             "type" "setv"
+             "value" (hy.models.Symbol "True")
+             "docs" "True"
+             "pos" #(1 1)})
+          #('(defclass Test [] (defn test [] True)) 
+            {"name" "Test"
+             "type" "defclass"
+             "docs" ""
+             "inherits" (hy.models.List)
+             "methods" [{"name" "test" 
+                         "type" "defn" 
+                         "docs" "" 
+                         "decorators" None 
+                         "args" (hy.models.List) 
+                         "pos" #(1 1)}]
+            "pos" #(1 1)})
+          #('(defn test [] True)
+            {"name" "test"
+             "type" "defn"
+             "docs" ""
+             "decorators" None
+             "args" (hy.models.List)
+             "pos" #(1 1)})
+          #('(defn test2 [input] "docstring" True) 
+            {"name" "test2"
+             "type" "defn"
+             "docs" "docstring"
+             "decorators" None
+             "args" (hy.models.List [(hy.models.Symbol "input")])
+             "pos" #(1 1)})])]
+  test_get-form-summary 
+  [form expected fixture-syms]
+  (print f"expected: { expected }")
+  (print f"got:      { (get-form-summary form) }")
+  (assert (= (get-form-summary form) expected)))
+


### PR DESCRIPTION
Expands pytest coverage from 24 to 56 tests, helping to address #3 .

- Added tests to `tests/api.hy`
- Created `tests/lspspec.hy`
- Created `tests/sym/summary.hy`

In addition to testing functionality, this also helps to document the inner workings of Hyuga supporting future feature development.