### PR TITLE
Support (Neo)Vim by coc.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ vim.api.nvim_create_autocmd("FileType", {
 
 Install [vim-lsp](https://github.com/prabirshrestha/vim-lsp) and [vim-lsp-settings](https://github.com/mattn/vim-lsp-settings), open a `*.hy` file with `filetype=hy`, then run `:LspInstallServer`
 
+- [coc-marketplace](https://github.com/fannheyward/coc-marketplace)
+- [npm](https://www.npmjs.com/package/hyuga-vscode-client)
+- vim:
+
+```vim
+" command line
+CocInstall hyuga-vscode-client
+" or add the following code to your vimrc
+let g:coc_global_extensions = ['hyuga-vscode-client', 'other coc-plugins']
+```
+
 ---
 
 ### [Visual Studio Code(VSCode)](https://code.visualstudio.com)

--- a/hyuga-vscode-client/.npmignore
+++ b/hyuga-vscode-client/.npmignore
@@ -1,0 +1,4 @@
+/*
+!/out/
+/out/test/
+*.map

--- a/hyuga-vscode-client/package.json
+++ b/hyuga-vscode-client/package.json
@@ -8,9 +8,11 @@
   "displayName": "Hyuga VSCode Client",
   "description": "Hy LSP(hyuga) Client for VSCode",
   "engines": {
+    "coc": "^0.0.82",
     "vscode": "^1.85.0"
   },
   "keywords": [
+    "coc.nvim",
     "hy",
     "hylang",
     "LSP"
@@ -37,9 +39,9 @@
     ]
   },
   "scripts": {
-    "package": "cp ../README.md ./ && cp ../LICENSE ./ && pnpm vsce package --no-dependencies",
-    "pre-release": "pnpm run package && pnpm vsce publish --no-dependencies --pre-release",
-    "publish": "pnpm run package && pnpm vsce publish --no-dependencies",
+    "vscode:package": "cp ../README.md ./ && cp ../LICENSE ./ && pnpm vsce package --no-dependencies",
+    "vscode:pre-release": "pnpm run package && pnpm vsce publish --no-dependencies --pre-release",
+    "vscode:publish": "pnpm run package && pnpm vsce publish --no-dependencies",
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
     "compile": "tsc -p ./",
@@ -59,9 +61,8 @@
     "eslint": "^8.28.0",
     "glob": "^8.0.3",
     "mocha": "^10.1.0",
+    "vscode-languageclient": "^9.0.1",
+    "coc.nvim": "^0.0.82",
     "typescript": "^4.9.3"
-  },
-  "dependencies": {
-    "vscode-languageclient": "^9.0.1"
   }
 }

--- a/hyuga-vscode-client/src/extension.ts
+++ b/hyuga-vscode-client/src/extension.ts
@@ -1,20 +1,36 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import * as vscode from 'vscode';
-import {LanguageClient} from "vscode-languageclient/node";
+import type { ExtensionContext as ExtensionContext_vscode } from 'vscode';
+import type {
+    LanguageClient as LanguageClient_vscode,
+} from 'vscode-languageclient/node';
+import type {
+    ExtensionContext as ExtensionContext_coc,
+    LanguageClient as LanguageClient_coc,
+} from 'coc.nvim';
+type ExtensionContext = ExtensionContext_vscode | ExtensionContext_coc;
+type LanguageClient = LanguageClient_vscode | LanguageClient_coc;
+let vscode, vlc;
+try {
+    vscode = require('vscode');
+    vlc = require('vscode-languageclient/node');
+} catch (error) {
+    vlc = require('coc.nvim');
+    vscode = vlc;
+}
+const LanguageClient = vlc.LanguageClient;
 
 let client: LanguageClient;
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: ExtensionContext) {
   // Use the console to output diagnostic information (console.log) and errors (console.error)
   // This line of code will only be executed once when your extension is activated
   console.info(`hyuga-vscode-client activation...`);
 
   try {
     const serverOptions = {
-      command: "python3",
-      args: ["-m", "hyuga"]
+      command: "hyuga",
     };
     const clientOptions = {
       documentSelector: [

--- a/hyuga-vscode-client/tsconfig.json
+++ b/hyuga-vscode-client/tsconfig.json
@@ -8,6 +8,8 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
+		"allowSyntheticDefaultImports": true,
+		"noImplicitAny": false,
 		"strict": true   /* enable all strict type-checking options */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */


### PR DESCRIPTION
![Screenshot_20250103_155404](https://github.com/user-attachments/assets/8f4ed1d0-5a1b-4398-9a26-011ac01dd53e)

https://www.npmjs.com/package/coc-hyuga

Refer:
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/src/extension.ts#L8-L14

Difference is vscode-ltex/coc-ltex uses a customized python script
https://github.com/valentjn/vscode-ltex/blob/3d0cb8cd9b4d0dc8ef6c08a4f376767820678cf6/tools/patchForTarget.py
to patch code
we use c language macro preprocessor cpp

Can you add me to collaborators to maintain the support of coc.nvim?
And I want to add your npm account to collaborators of npm package of coc-hyuga due to
most code comes from you.
TIA!
